### PR TITLE
Add basic charm functionality and utilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-To make contributions to this charm, you'll need a working [development setup](https://juju.is/docs/sdk/dev-setup).
+To make contributions to this charm, you'll need a working
+[development setup](https://juju.is/docs/sdk/dev-setup).
 
 You can create an environment for development with `tox`:
 
@@ -11,8 +12,9 @@ source venv/bin/activate
 
 ## Testing
 
-This project uses `tox` for managing test environments. There are some pre-configured environments
-that can be used for linting and formatting code when you're preparing contributions to the charm:
+This project uses `tox` for managing test environments. There are some
+pre-configured environments that can be used for linting and formatting code
+when you're preparing contributions to the charm:
 
 ```shell
 tox run -e format        # update your code according to linting rules
@@ -23,12 +25,8 @@ tox run -e integration   # integration tests
 tox                      # runs 'format', 'lint', 'static', and 'unit' environments
 ```
 
-## Build the charm
+### Deploy
 
-Build the charm in this git repository using:
-
-```shell
-charmcraft pack
-```
-
-<!-- You may want to include any contribution/style guidelines in this document>
+Please refer to the
+[Airbyte server charm documentation](https://github.com/canonical/airbyte-k8s-operator/blob/main/CONTRIBUTING.md)
+for instructions about how to deploy the web UI and relate it to the server.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
-<!--
-Avoid using this README file for information that is maintained or published elsewhere, e.g.:
+# Airbyte UI K8s Operator
 
-* metadata.yaml > published on Charmhub
-* documentation > published on (or linked to from) Charmhub
-* detailed contribution guide > documentation or CONTRIBUTING.md
+This is the Kubernetes Python Operator for the
+[Airybte web UI](https://airbyte.com/).
 
-Use links instead.
--->
+## Description
 
-# airbyte-ui-k8s-operator
+Airbyte is an open-source data integration platform designed to centralize and
+streamline the process of extracting and loading data from various sources into
+data warehouses, lakes, or other destinations.
 
-Charmhub package name: operator-template
-More information: https://charmhub.io/airbyte-ui-k8s-operator
+This operator provides the Airbyte web UI, and consists of Python scripts which
+wraps the versions distributed by
+[airbyte](https://hub.docker.com/r/airbyte/webapp).
 
-Describe your charm in one or two sentences.
+## Usage
 
-## Other resources
+Please check the [Airbyte server operator](https://charmhub.io/airbyte-k8s) for
+usage instructions.
 
-<!-- If your charm is documented somewhere else other than Charmhub, provide a link separately. -->
+## Contributing
 
-- [Read more](https://example.com)
+This charm is still in active development. Please see the
+[Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this
+charm following best practice guidelines, and `CONTRIBUTING.md` for developer
+guidance.
 
-- [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+## License
 
-- See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.
+The Charmed Airbyte UI K8s Operator is free software, distributed under the
+Apache Software License, version 2.0. See [License](LICENSE) for more details.

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,5 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+restart:
+  description: Restart the Airbyte Web UI.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,39 +1,19 @@
 # This file configures Charmcraft.
 # See https://juju.is/docs/sdk/charmcraft-config for guidance.
 
-# (Required)
-# The charm package name, no spaces
-# See https://juju.is/docs/sdk/naming#heading--naming-charms for guidance.
-name: airbyte-ui-k8s-operator
-
-
-# (Required)
-# The charm type, either 'charm' or 'bundle'.
+name: airbyte-ui-k8s
 type: charm
-
-
-# (Recommended)
-title: Charm Template
-
-
-# (Required)
-summary: A very short one-line summary of the charm.
-
-
-# (Required)
+title: Airbyte Web UI
+summary: Airbyte Web UI operator
 description: |
-  A single sentence that says what the charm is, concisely and memorably.
-
-  A paragraph of one to three short sentences, that describe what the charm does.
-
-  A third paragraph that explains what need the charm meets.
-
-  Finally, a paragraph that describes whom the charm is useful for.
-
+  Airbyte is an open-source data integration platform designed to centralize and 
+  streamline the process of extracting and loading data from various sources into 
+  data warehouses, lakes, or other destinations.
+  
+  This charm provides the web UI which can be related to the Airbyte server charm
+  to view and configure different connections.
 
 # (Required for 'charm' type)
-# A list of environments (OS version and architecture) where charms must be
-# built on and run on.
 bases:
   - build-on:
     - name: ubuntu
@@ -42,6 +22,11 @@ bases:
     - name: ubuntu
       channel: "22.04"
 
+
+# Metadata
+peers:
+  peer:
+    interface: airbyte
 
 # (Optional) Configuration options for the charm
 # This config section defines charm config options, and populates the Configure
@@ -62,24 +47,15 @@ config:
 
 # The containers and resources metadata apply to Kubernetes charms only.
 # See https://juju.is/docs/sdk/metadata-reference for a checklist and guidance.
-# Remove them if not required.
-
 
 # Your workload’s containers.
 containers:
-  httpbin:
-    resource: httpbin-image
-
+  airbyte-webapp:
+    resource: airbyte-webapp
 
 # This field populates the Resources tab on Charmhub.
 resources:
-  # An OCI image resource for each container listed above.
-  # You may remove this if your charm will run without a workload sidecar container.
-  httpbin-image:
+  airbyte-webapp:
     type: oci-image
-    description: OCI image for httpbin
-    # The upstream-source field is ignored by Juju. It is included here as a
-    # reference so the integration testing suite knows which image to deploy
-    # during testing. This field is also used by the 'canonical/charming-actions'
-    # Github action for automated releasing.
-    upstream-source: kennethreitz/httpbin
+    description: OCI image for Airbyte web UI
+    upstream-source: airbyte/webapp:0.57.3

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,103 +1,142 @@
 #!/usr/bin/env python3
-# Copyright 2024 Ali
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-#
-# Learn more at: https://juju.is/docs/sdk
 
-"""Charm the service.
-
-Refer to the following tutorial that will help you
-develop a new k8s charm using the Operator Framework:
-
-https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm
-"""
+"""Charm definition and helpers."""
 
 import logging
 
-import ops
+from log import log_event_handler
+from ops import main, pebble
+from ops.charm import CharmBase
+from ops.model import ActiveStatus, MaintenanceStatus
+from ops.pebble import CheckStatus
+from state import State
 
-# Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
-VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
+WEB_UI_PORT = 8080
 
 
-class AirbyteUiK8SOperatorCharm(ops.CharmBase):
-    """Charm the service."""
+class AirbyteK8SOperatorCharm(CharmBase):
+    """Charm the application."""
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.framework.observe(self.on['httpbin'].pebble_ready, self._on_httpbin_pebble_ready)
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self._state = State(self.app, lambda: self.model.get_relation("peer"))
 
-    def _on_httpbin_pebble_ready(self, event: ops.PebbleReadyEvent):
-        """Define and start a workload using the Pebble API.
+        self.name = "airbyte-webapp"
+        self.framework.observe(self.on[self.name].pebble_ready, self._on_pebble_ready)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.restart_action, self._on_restart)
 
-        Change this example to suit your needs. You'll need to specify the right entrypoint and
-        environment configuration for your specific workload.
+    @log_event_handler(logger)
+    def _on_pebble_ready(self, event):
+        """Handle pebble-ready event."""
+        self._update(event)
 
-        Learn more about interacting with Pebble at at https://juju.is/docs/sdk/pebble.
+    @log_event_handler(logger)
+    def _on_update_status(self, event):
+        """Handle `update-status` events.
+
+        Args:
+            event: The `update-status` event triggered at intervals.
         """
-        # Get a reference the container attribute on the PebbleReadyEvent
-        container = event.workload
-        # Add initial Pebble config layer using the Pebble API
-        container.add_layer("httpbin", self._pebble_layer, combine=True)
-        # Make Pebble reevaluate its plan, ensuring any services are started if enabled.
-        container.replan()
-        # Learn more about statuses in the SDK docs:
-        # https://juju.is/docs/sdk/constructs#heading--statuses
-        self.unit.status = ops.ActiveStatus()
+        container = self.unit.get_container(self.name)
+        valid_pebble_plan = self._validate_pebble_plan(container)
+        if not valid_pebble_plan:
+            self._update(event)
+            return
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent):
-        """Handle changed configuration.
+        check = container.get_check("up")
+        if check.status != CheckStatus.UP:
+            self.unit.status = MaintenanceStatus("Status check: DOWN")
+            return
 
-        Change this example to suit your needs. If you don't need to handle config, you can remove
-        this method.
+        self.unit.status = ActiveStatus()
 
-        Learn more about config at https://juju.is/docs/sdk/config
+    def _validate_pebble_plan(self, container):
+        """Validate pebble plan.
+
+        Args:
+            container: application container
+
+        Returns:
+            bool of pebble plan validity
         """
-        # Fetch the new config value
-        log_level = self.model.config["log-level"].lower()
+        try:
+            plan = container.get_plan().to_dict()
+            return bool(plan["services"][self.name]["on-check-failure"])
+        except (KeyError, pebble.ConnectionError):
+            return False
 
-        # Do some validation of the configuration option
-        if log_level in VALID_LOG_LEVELS:
-            # The config is good, so update the configuration of the workload
-            container = self.unit.get_container("httpbin")
-            # Verify that we can connect to the Pebble API in the workload container
-            if container.can_connect():
-                # Push an updated layer with the new config
-                container.add_layer("httpbin", self._pebble_layer, combine=True)
-                container.replan()
+    def _on_restart(self, event):
+        """Restart Airbyte ui action handler.
 
-                logger.debug("Log level for gunicorn changed to '%s'", log_level)
-                self.unit.status = ops.ActiveStatus()
-            else:
-                # We were unable to connect to the Pebble API, so we defer this event
-                event.defer()
-                self.unit.status = ops.WaitingStatus("waiting for Pebble API")
-        else:
-            # In this case, the config option is bad, so block the charm and notify the operator.
-            self.unit.status = ops.BlockedStatus("invalid log level: '{log_level}'")
+        Args:
+            event:The event triggered by the restart action
+        """
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.defer()
+            return
 
-    @property
-    def _pebble_layer(self) -> ops.pebble.LayerDict:
-        """Return a dictionary representing a Pebble layer."""
-        return {
-            "summary": "httpbin layer",
-            "description": "pebble config layer for httpbin",
+        self.unit.status = MaintenanceStatus("restarting application")
+        container.restart(self.name)
+        self.unit.status = ActiveStatus()
+
+        event.set_results({"result": "UI successfully restarted"})
+
+    @log_event_handler(logger)
+    def _update(self, event):
+        """Update the Airbyte UI configuration and replan its execution.
+
+        Args:
+            event: The event triggered when the relation changed.
+        """
+        # TODO (kelkawi-a): validate presence of Airbyte server relation
+        # TODO (kelkawi-a): update this to get server application name through charm relation
+        context = {
+            "API_URL": "/api/v1/",
+            "AIRBYTE_EDITION": "community",
+            "INTERNAL_API_HOST": "airbyte-k8s:8001",
+            "CONNECTOR_BUILDER_API_HOST": "airbyte-k8s:80",
+            "KEYCLOAK_INTERNAL_HOST": "localhost",
+        }
+
+        self.model.unit.set_ports(8080)
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.defer()
+            return
+
+        pebble_layer = {
+            "summary": "airbyte layer",
             "services": {
-                "httpbin": {
-                    "override": "replace",
-                    "summary": "httpbin",
-                    "command": "gunicorn -b 0.0.0.0:80 httpbin:app -k gevent",
+                self.name: {
+                    "summary": "airbyte webapp",
+                    "command": "./docker-entrypoint.sh nginx",
                     "startup": "enabled",
-                    "environment": {
-                        "GUNICORN_CMD_ARGS": f"--log-level {self.model.config['log-level']}"
-                    },
+                    "override": "replace",
+                    # Including config values here so that a change in the
+                    # config forces replanning to restart the service.
+                    "environment": context,
+                    "on-check-failure": {"up": "ignore"},
+                },
+            },
+            "checks": {
+                "up": {
+                    "override": "replace",
+                    "period": "10s",
+                    "http": {"url": f"http://localhost:{WEB_UI_PORT}"},
                 }
             },
         }
+        container.add_layer(self.name, pebble_layer, combine=True)
+        container.replan()
+
+        self.unit.status = MaintenanceStatus("replanning application")
 
 
 if __name__ == "__main__":  # pragma: nocover
-    ops.main(AirbyteUiK8SOperatorCharm)  # type: ignore
+    main.main(AirbyteK8SOperatorCharm)  # type: ignore

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 WEB_UI_PORT = 8080
 
 
-class AirbyteK8SOperatorCharm(CharmBase):
+class AirbyteUIK8sOperatorCharm(CharmBase):
     """Charm the application."""
 
     def __init__(self, *args):
@@ -83,7 +83,6 @@ class AirbyteK8SOperatorCharm(CharmBase):
 
         self.unit.status = MaintenanceStatus("restarting application")
         container.restart(self.name)
-        self.unit.status = ActiveStatus()
 
         event.set_results({"result": "UI successfully restarted"})
 
@@ -104,7 +103,7 @@ class AirbyteK8SOperatorCharm(CharmBase):
             "KEYCLOAK_INTERNAL_HOST": "localhost",
         }
 
-        self.model.unit.set_ports(8080)
+        self.model.unit.set_ports(WEB_UI_PORT)
         container = self.unit.get_container(self.name)
         if not container.can_connect():
             event.defer()
@@ -114,7 +113,7 @@ class AirbyteK8SOperatorCharm(CharmBase):
             "summary": "airbyte layer",
             "services": {
                 self.name: {
-                    "summary": "airbyte webapp",
+                    "summary": self.name,
                     "command": "./docker-entrypoint.sh nginx",
                     "startup": "enabled",
                     "override": "replace",
@@ -139,4 +138,4 @@ class AirbyteK8SOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main.main(AirbyteK8SOperatorCharm)  # type: ignore
+    main.main(AirbyteUIK8sOperatorCharm)  # type: ignore

--- a/src/log.py
+++ b/src/log.py
@@ -1,0 +1,47 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Define logging helpers."""
+
+import functools
+
+
+def log_event_handler(logger):
+    """Log with the provided logger when a event handler method is executed.
+
+    Args:
+        logger: logger used to log events.
+
+    Returns:
+        Decorator wrapper.
+    """
+
+    def decorator(method):
+        """Log decorator wrapper.
+
+        Args:
+            method: method wrapped by the decorator.
+
+        Returns:
+            Decorated method.
+        """
+
+        @functools.wraps(method)
+        def decorated(self, event):
+            """Log decorator method.
+
+            Args:
+                event: The event triggered when the relation changes.
+
+            Returns:
+                Decorated method.
+            """
+            logger.info(f"* running {self.__class__.__name__}.{method.__name__}")
+            try:
+                return method(self, event)
+            finally:
+                logger.info(f"* completed {self.__class__.__name__}.{method.__name__}")
+
+        return decorated
+
+    return decorator

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for handling charm state."""
+
+import json
+
+
+class State:
+    """A magic state that uses a relation as the data store.
+
+    The get_relation callable is used to retrieve the relation.
+    As relation data values must be strings, all values are JSON encoded.
+    """
+
+    def __init__(self, app, get_relation):
+        """Construct.
+
+        Args:
+            app: workload application
+            get_relation: get peer relation method
+        """
+        # Use __dict__ to avoid calling __setattr__ and subsequent infinite recursion.
+        self.__dict__["_app"] = app
+        self.__dict__["_get_relation"] = get_relation
+
+    def __setattr__(self, name, value):
+        """Set a value in the store with the given name.
+
+        Args:
+            name: name of value to set in store.
+            value: value to set in store.
+        """
+        v = json.dumps(value)
+        self._get_relation().data[self._app].update({name: v})
+
+    def __getattr__(self, name):
+        """Get from the store the value with the given name, or None.
+
+        Args:
+            name: name of value to get from store.
+
+        Returns:
+            value from store with given name.
+        """
+        v = self._get_relation().data[self._app].get(name, "null")
+        return json.loads(v)
+
+    def __delattr__(self, name):
+        """Delete the value with the given name from the store, if it exists.
+
+        Args:
+            name: name of value to delete from store.
+
+        Returns:
+            deleted value from store.
+        """
+        return self._get_relation().data[self._app].pop(name, None)
+
+    def is_ready(self):
+        """Report whether the relation is ready to be used.
+
+        Returns:
+            A boolean representing whether the relation is ready to be used or not.
+        """
+        return bool(self._get_relation())


### PR DESCRIPTION
This PR adds basic functionality to the Airbyte UI charm:

- Adds OCI image and entry point to start the application
- Adds update status hook logic to start the application based on a liveness check
- Adds peer relation for sharing state across units
- Adds logging utility
- Adds restart action
- Updates README and contributing guidelines

Note: Some links point to pages in the Airbyte Charmhub page and server repo which may not exist yet.